### PR TITLE
Feature/add max capacity limit per key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,8 @@ type DeltaConfig struct {
 		MaxSizeToSplit     int64 `env:"MAX_SIZE_TO_SPLIT" envDefault:"10000000000"`
 		DealCheck          int   `env:"DEAL_CHECK" envDefault:"600"`
 		ReplicationFactor  int   `env:"REPLICATION_FACTOR" envDefault:"0"`
+		// Capacity Limit per Key: default 0 - unlimited
+		CapacityLimitPerKeyInBytes int64 `env:"CAPACITY_LIMIT_PER_KEY_IN_BYTES" evnDefault:"0"`
 	}
 
 	ExternalApi struct {

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ type DeltaConfig struct {
 		DealCheck          int   `env:"DEAL_CHECK" envDefault:"600"`
 		ReplicationFactor  int   `env:"REPLICATION_FACTOR" envDefault:"0"`
 		// Capacity Limit per Key: default 0 - unlimited
-		CapacityLimitPerKeyInBytes int64 `env:"CAPACITY_LIMIT_PER_KEY_IN_BYTES" evnDefault:"0"`
+		CapacityLimitPerKeyInBytes int64 `env:"CAPACITY_LIMIT_PER_KEY_IN_BYTES" envDefault:"0"`
 	}
 
 	ExternalApi struct {


### PR DESCRIPTION
Added new config for setting up key/token capacity limit (optional)

New attribute can be added to the .env to control how much capacity keys/tokens can upload.

.env (optional)
CAPACITY_LIMIT_PER_KEY_IN_BYTES=5368709120