### PR TITLE
Modify Edge to allow for custom IPFS ports

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,8 @@ type DeltaConfig struct {
 		Repo        string `env:"REPO" envDefault:"./whypfs"`
 		DsRepo      string `env:"DS_REPO" envDefault:"./whypfs"`
 		Port        int    `env:"PORT" envDefault:"1414"`
+		IpfsPort	int    `env:"IPFS_PORT" envDefault:"6745"`
+		PublicIp	string `env:"PUBLIC_IP"`
 	}
 
 	Delta struct {

--- a/core/node.go
+++ b/core/node.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -64,17 +65,33 @@ func NewEdgeNode(ctx context.Context, cfg config.DeltaConfig) (*LightNode, error
 
 	db, err := OpenDatabase(cfg)
 	// node
-	publicIp, err := GetPublicIP()
+	// If we don't have an explicit Public IP set as an env var, fetch one
+	var publicIp string
+
+	if cfg.Node.PublicIp == "" {
+		publicIp, err = GetPublicIP()
+		if err != nil {
+			fmt.Printf("Error getting public IP: %v", err)
+		}
+	} else {
+		publicIp = cfg.Node.PublicIp
+	}
+	// Fetch the IpfsPort from DeltaConfig
+	IpfsPort := strconv.Itoa(cfg.Node.IpfsPort)
+
 	newConfig := &whypfs.Config{
 		ListenAddrs: []string{
-			"/ip4/0.0.0.0/tcp/6745",
-			"/ip4/" + publicIp + "/tcp/6745",
+			"/ip4/0.0.0.0/tcp/" + IpfsPort,
+			"/ip4/" + publicIp + "/tcp/" + IpfsPort,
 		},
 		AnnounceAddrs: []string{
-			"/ip4/0.0.0.0/tcp/6745",
-			"/ip4/" + publicIp + "/tcp/6745",
+			"/ip4/0.0.0.0/tcp/" + IpfsPort,
+			"/ip4/" + publicIp + "/tcp/" + IpfsPort,
 		},
+		
 	}
+
+	fmt.Printf("IPFS config: %v", newConfig)
 
 	params := whypfs.NewNodeParams{
 		Ctx:       ctx,

--- a/core/node.go
+++ b/core/node.go
@@ -91,8 +91,6 @@ func NewEdgeNode(ctx context.Context, cfg config.DeltaConfig) (*LightNode, error
 		
 	}
 
-	fmt.Printf("IPFS config: %v", newConfig)
-
 	params := whypfs.NewNodeParams{
 		Ctx:       ctx,
 		Datastore: datastore.NewMapDatastore(),


### PR DESCRIPTION
This PR is a hopefully relatively small modification that adds the ability to specify an IPFS port and public IP to use on a node by setting the env vars IPFS_PORT and PUBLIC_IP.

It is necessary to enable public serving of IPFS content within the Edge Carriers.